### PR TITLE
Use MEDIA_URL in base.html template to enable use of static file hosting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.*.swp
+*.pyc
+build/
+dist/
+*.egg-info

--- a/siptrackweb/templates/stweb/base.html
+++ b/siptrackweb/templates/stweb/base.html
@@ -3,8 +3,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 	<head>
 		<title>{% block title %}siptrackweb{% endblock %}</title>
-		<link rel="stylesheet" href="/style.css" />
-		<script src="/prototype.js" type="text/javascript"></script>
+    <link rel="stylesheet" href="{{MEDIA_ROOT}}/style.css" />
+    <script src="{{MEDIA_ROOT}}/prototype.js" type="text/javascript"></script>
 	</head>
 
 	<body>


### PR DESCRIPTION
I think MEDIA_URL should be used in the base.html template so that people can host the static files separately. 

This is a non-invasive change that would not break compatibility unless MEDIA_URL is defined. When left undefined it will be empty and the old URL of /prototype.js or /style.css will be used. 
