### PR TITLE
fixed deleted password keys crashing the user info display page.

### DIFF
--- a/siptrackweb/templates/stweb/users/display_subkeys.html
+++ b/siptrackweb/templates/stweb/users/display_subkeys.html
@@ -9,22 +9,26 @@
 <div class="content-data">
 	<div id="display_subkeys">
 		{% if subkey_list %}
-		<table class="infotable">
-			<tr>
-				<th class="infotable">Name</th>
-				<th class="infotable">Description</th>
-				<th class="infotable">Action</th>
-			</tr>
+		<table class="table-hover table-striped infotable">
+      <thead>
+        <tr>
+          <th class="infotable">Name</th>
+          <th class="infotable">Description</th>
+          <th class="infotable">Action</th>
+        </tr>
+      </thead>
 			{% for subkey in subkey_list %}
-				{% if forloop.counter|divisibleby:"2" %}
-				<tr class="infotableeven">
-				{% else %}
-				<tr class="infotableodd">
-				{% endif %}
-					<td>{{ subkey.password_key.attributes.name|escape }}</td>
-					<td>{{ subkey.password_key.attributes.description|escape }}</td>
-					<td class="center">{% if write_access %}<a href="/user/subkey/delete/{{ subkey.oid }}/">disconnect</a>{% endif %}</td>
-				</tr>
+      <tr>
+        {% if subkey.exists %}
+          <!-- Jinja2 will never display this. -->
+          <td>Password key deleted</td>
+          <td>Password key deleted</td>
+        {% else %}
+          <td>{{ subkey.password_key.attributes.name|escape }}</td>
+          <td>{{ subkey.password_key.attributes.description|escape }}</td>
+        {% endif %}
+        <td class="center">{% if write_access %}<a href="/user/subkey/delete/{{ subkey.oid }}/">disconnect</a>{% endif %}</td>
+      </tr>
 			{% endfor %}
 		</table>
 		{% endif %}

--- a/siptrackweb/views/user.py
+++ b/siptrackweb/views/user.py
@@ -183,7 +183,15 @@ def display(request, oid):
 
     user = pm.setVar('user', pm.object_store.getOID(oid))
     pm.render_var['attribute_list'] = attribute.parse_attributes(user)
-    pm.render_var['subkey_list'] = user.listChildren(include = ['sub key'])
+    subkey_list = []
+    for subkey in user.listChildren(include=['sub key']):
+        try:
+            pw_key = subkey.password_key
+        except siptracklib.errors.NonExistent as e:
+            subkey_list.append({'oid': subkey.oid, 'exists': False})
+            continue
+        subkey_list.append(subkey)
+    pm.render_var['subkey_list'] = subkey_list
     pm.path(user)
     return pm.render()
 


### PR DESCRIPTION
This fixes issue #3 

Instead of trying to delete all the orphaned subkeys from all the users when the password key is deleted I instead opted to simply handle the siptracklib.errors.NonExistent exception and display an empty subkey with a disconnect link so the user themselves can disconnect it at their leisure. 
